### PR TITLE
jsonschema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "portscanner": "^2.2.0",
     "nodemailer": "^4.6.8",
     "nodemailer-smtp-transport": "^2.7.4",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "jsonschema": "^1.2.4"
   },
   "devDependencies": {
     "eslint": "^5.6.1"

--- a/src/schemas/catalog.js
+++ b/src/schemas/catalog.js
@@ -1,0 +1,52 @@
+const catalogItem = {
+  "id": "/catalogItem",
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "category": {"type": "string"},
+    "publisher": {"type": "string"},
+    "diskRequired": {"type": "integer"},
+    "ramRequired": {"type": "integer"},
+    "picture": {"type": "string"},
+    "isPublic": {"type": "boolean"},
+    "registryId": {"type": "integer"},
+    "configExample": {"type": "string"},
+    "images": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": {"$ref": "/image"}},
+    "inputType": {"$ref": "/type"},
+    "outputType": {"$ref": "/type"}
+  },
+  "required": ["name", ]
+};
+
+const image = {
+  "id": "/image",
+  "type": "object",
+  "properties": {
+    "containerImage": {"type": "string"},
+    "fogTypeId":
+      {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 2
+      }
+  }
+};
+
+const type = {
+  "id": "/type",
+  "type": "object",
+  "properties": {
+    "infoType": {"type": "string"},
+    "infoFormat": {"type": "string"}
+  }
+};
+
+module.exports = {
+  mainSchemas: [catalogItem],
+  innerSchemas: [image, type]
+};

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,0 +1,47 @@
+const Validator = require('jsonschema').Validator;
+const fs = require('fs');
+const path = require('path');
+
+const basename = path.basename(__filename);
+
+const Errors = require('../helpers/errors');
+
+const v = new Validator();
+const schemas = {};
+
+const registerSchema = (schema, schemaName) => {
+  v.addSchema(schema, schemaName);
+};
+
+fs.readdirSync(__dirname)
+  .filter(file => {
+    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+  })
+  .forEach(file => {
+    const allSchemas = require(path.join(__dirname, file));
+
+    const mainSchemas = allSchemas.mainSchemas;
+    const innerSchemas = allSchemas.innerSchemas;
+
+    mainSchemas.forEach(schema => {
+      schemas[schema.id.replace('/', '')] = schema;
+    });
+
+    innerSchemas.forEach(schema => {
+      registerSchema(schema, schema.id);
+    });
+  });
+
+
+async function validate(req, schema) {
+  const response = v.validate(req.body, schema);
+  if (!response.valid) {
+    throw new Errors.ValidationError(response.errors[0].stack)
+  }
+  return response
+}
+
+module.exports = {
+  validate,
+  schemas
+};


### PR DESCRIPTION
Validation using jsonschema for required/not required fields, field types, logic validation, enums, etc.
1 file per 1 section in /sections

mainSchemas - for direct validate() calls, inner - for inner objects inside mainSchemas.

Usage:
const Validation = require('../schemas');

await Validation.validate(req, Validation.schemas.catalogItem);