### PR TITLE
Remove duplicate `volumeMappings` key in swagger

### DIFF
--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -2761,10 +2761,6 @@ definitions:
            $ref: '#/definitions/VolumeMappingAgentRequest'
       imageSnapshot:
         type: string
-      volumeMappings:
-         type: array
-         items:
-           $ref: '#/definitions/VolumeMappingAgentRequest'
       ports:
         $ref: '#/definitions/PortMappingsRequest'
       routes:


### PR DESCRIPTION
Today one of the PRs added a duplicate `volumeMappings` key causing swagger validation to fail. I believe it's the same content as well, so it can just be removed.

![image](https://user-images.githubusercontent.com/762949/47328289-99b6a380-d63e-11e8-8e1e-2ce7045b249b.png)

(newline added was because I edited using github UI :shipit: )